### PR TITLE
fix(hide-md): Improve how reference-style Markdown links are rendered (#17)

### DIFF
--- a/src/contentScript/replace/replaceFormatCharacters.ts
+++ b/src/contentScript/replace/replaceFormatCharacters.ts
@@ -38,8 +38,6 @@ const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
 		return true;
 	}
 
-	console.log('node', node.name, state.sliceDoc(node.from, node.to));
-	
 	if ((node.name === 'URL' || node.name === 'LinkMark') && getParentName() === 'Link') {
 		const parentContent = state.sliceDoc(node.node.parent!.from, node.node.parent!.to);
 		if (node.name === 'LinkMark') {

--- a/src/contentScript/replace/replacementExtension.ts
+++ b/src/contentScript/replace/replacementExtension.ts
@@ -3,6 +3,7 @@ import replaceBulletLists from "./replaceBulletLists";
 import replaceCheckboxes from "./replaceCheckboxes";
 import replaceDividers from "./replaceDividers";
 import replaceFormatCharacters from "./replaceFormatCharacters";
+import referenceLinkStateField from "./utils/referenceLinksStateField";
 
 export default [
 	replaceCheckboxes,

--- a/src/contentScript/replace/utils/referenceLinksStateField.ts
+++ b/src/contentScript/replace/utils/referenceLinksStateField.ts
@@ -20,17 +20,14 @@ export const resolveReferenceById = (referenceId: string, state: EditorState) =>
 const referenceLinkExp = /^(\[[^\]]+\])\s*(\[[^\]]+\])?$/;
 
 export const isReferenceLink = (link: string) => {
-	console.log('isReferenceLink', link);
 	return !!link.trim().match(referenceLinkExp);
 }
 
 export const resolveReferenceFromLink = (link: string, state: EditorState) => {
-	console.log('lookup', link);
 	const referenceMatch = link.trim().match(referenceLinkExp);
 	if (!referenceMatch) return null;
 
 	const resolved = resolveReferenceById(referenceMatch[2] ?? referenceMatch[1], state);
-	console.log('resv', resolved);
 	return resolved;
 };
 

--- a/src/contentScript/replace/utils/referenceLinksStateField.ts
+++ b/src/contentScript/replace/utils/referenceLinksStateField.ts
@@ -1,0 +1,97 @@
+import { EditorState, Line, RangeSet, Range, RangeValue, StateField, Text, Transaction } from "@codemirror/state";
+
+class ReferenceLinkValue extends RangeValue {
+	public constructor(public readonly key: string, public readonly value: string) {
+		super();
+	}	
+}
+
+export const resolveReferenceById = (referenceId: string, state: EditorState) => {
+	const cursor = state.field(referenceLinkStateField).iter();
+	for (; !!cursor.value; cursor.next()) {
+		if (cursor.value.key === referenceId) {
+			return cursor.value.value;
+		}
+	}
+
+	return null;
+};
+
+const referenceLinkExp = /^(\[[^\]]+\])\s*(\[[^\]]+\])?$/;
+
+export const isReferenceLink = (link: string) => {
+	console.log('isReferenceLink', link);
+	return !!link.trim().match(referenceLinkExp);
+}
+
+export const resolveReferenceFromLink = (link: string, state: EditorState) => {
+	console.log('lookup', link);
+	const referenceMatch = link.trim().match(referenceLinkExp);
+	if (!referenceMatch) return null;
+
+	const resolved = resolveReferenceById(referenceMatch[2] ?? referenceMatch[1], state);
+	console.log('resv', resolved);
+	return resolved;
+};
+
+
+// Returns the key and value for a link reference definition in the form
+// [a test]: http://some/def/here/
+const parseReferenceDef = (lineText: string) => {
+	const linkStart = lineText.match(/^(\[[^\[\]]+\]):/);
+	if (!linkStart) return null;
+
+	const key = linkStart[1];
+	return {
+		key,
+		value: lineText.substring(linkStart[0].length),
+	};
+};
+
+const addReferencesToSet = (set: RangeSet<ReferenceLinkValue>, fromIdx: number, toIdx: number, doc: Text) => {
+	const newRanges: Range<ReferenceLinkValue>[] = [];
+
+	const fromLine = doc.lineAt(fromIdx);
+	const toLine = doc.lineAt(toIdx);
+
+	for (let i = fromLine.number; i <= toLine.number; i++) {
+		const line = doc.line(i);
+		const parsedRef = parseReferenceDef(line.text);
+		if (parsedRef) {
+			newRanges.push(
+				new ReferenceLinkValue(parsedRef.key, parsedRef.value).range(line.from),
+			);
+		}
+	}
+
+	return set.update({ add: newRanges });
+};
+
+const referenceLinkStateField = StateField.define<RangeSet<ReferenceLinkValue>>({
+	create(state): RangeSet<ReferenceLinkValue> {
+		return addReferencesToSet(RangeSet.empty, 0, state.doc.length, state.doc);
+	},
+	update(value, transaction) {
+		if (!transaction.docChanged) return value.map(transaction.changes);
+
+		// Remove deleted/modified definitions
+		transaction.changes.iterChangedRanges((fromA, toA) => {
+			value = value.update({
+				filterFrom: fromA,
+				filterTo: toA,
+				filter: () => false,
+			});
+		});
+
+		// Switch line numbers to match the new document
+		value = value.map(transaction.changes);
+
+		transaction.changes.iterChangedRanges((_fromA, _fromB, fromB, toB) => {
+			value = addReferencesToSet(value, fromB, toB, transaction.newDoc);
+		});
+
+		return value;
+	},
+});
+
+export default referenceLinkStateField;


### PR DESCRIPTION
# Summary

This is a work-in-progress pull request that should fix #17. It:
- **Hidden Markdown mode**: Checks that a URL is associated with a [reference link](https://www.markdownguide.org/basic-syntax/#reference-style-links) before hiding the link's `[` and `]`.
- **Link popup**: Adds support for showing the link popup for reference-style links.

**To-do**: Testing.